### PR TITLE
Update promotional messaging after pricing changes

### DIFF
--- a/notifications.json
+++ b/notifications.json
@@ -1,8 +1,8 @@
 {
     "notifications": [{
         "id": "1",
-        "title": "Special: 50% off GitKraken tools",
-        "description": "1st and 2nd seats only $4/mo each",
+        "title": "Limited-time Sale",
+        "description": "Save 33% or more on your 1st seat of GitKraken Pro",
         "trigger": ["trial"]
     }],
     "version": 1


### PR DESCRIPTION
The price of the first seat of GitKraken Pro (tier 1 regions) is now $6, discounted from $9. Since we have different prices for various regions, this messaging needed to show the lowest discount and remove mention of specific $ amounts.